### PR TITLE
fix: handle missing changes folder gracefully

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,12 +187,20 @@ const processChange = (pr, sameLevelChanges, prefix) => {
 }
 
 const findFile = async(octokit, organization, repo, fileName, branch) => {
-  gitFile = await octokit.rest.repos.getContent({
-    owner: organization,
-    repo: repo,
-    path: fileName,
-  })
-  return gitFile.data;
+  try {
+    gitFile = await octokit.rest.repos.getContent({
+      owner: organization,
+      repo: repo,
+      path: fileName,
+    })
+    return gitFile.data;
+  } catch (error) {
+    if (error.status === 404) {
+      console.log(`Path '${fileName}' not found in repository. No changes to process.`);
+      return [];
+    }
+    throw error;
+  }
 }
 
 main()


### PR DESCRIPTION
## Summary
- Add error handling to `findFile` function to catch 404 errors from GitHub API
- Return empty array when `/changes` folder doesn't exist instead of crashing
- Action now completes successfully with empty changelog when no changes folder is present

## Test plan
- [ ] Run action on a repository without a `/changes` folder - should complete without error
- [ ] Run action on a repository with a `/changes` folder - should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)